### PR TITLE
Fix sub-command case sensitivity and jungle trees not dropping saplings

### DIFF
--- a/src/me/jonahisadev/treeme/ChopCommand.java
+++ b/src/me/jonahisadev/treeme/ChopCommand.java
@@ -36,7 +36,7 @@ public class ChopCommand implements CommandExecutor {
             }
 
             // Commands
-            switch (args[0]) {
+            switch (args[0].toLowerCase()) {
                 case "toggle": {
                     _plugin.playerStore.toggle(player.getUniqueId(), "enabled");
                     boolean state = _plugin.playerStore.state(player.getUniqueId()).enabled;

--- a/src/me/jonahisadev/treeme/Types.java
+++ b/src/me/jonahisadev/treeme/Types.java
@@ -62,6 +62,9 @@ public class Types {
             case ACACIA_LOG:
             case STRIPPED_ACACIA_LOG:
                 return Material.ACACIA_SAPLING;
+            case JUNGLE_LOG:
+            case STRIPPED_JUNGLE_LOG:
+                return Material.JUNGLE_SAPLING;
             default:
                 return Material.AIR;
         }


### PR DESCRIPTION
Converts sub-command argument for /TreeMe to lowercase to prevent case-sensitivity issues.
Adds jungle logs and saplings to the sameSapling method in the Types class to fix an issue where jungle trees would not drop saplings when chopped.